### PR TITLE
added gotty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,15 @@
+FROM alpine:3.18.6 AS builder
+
+RUN apk update && apk add --virtual .build-deps \
+    build-base gcc
+
+RUN wget https://github.com/troglobit/mcjoin/releases/download/v2.11/mcjoin-2.11.tar.gz
+RUN tar -xzf mcjoin-2.11.tar.gz
+WORKDIR /mcjoin-2.11
+RUN ./configure
+RUN make -j5
+RUN make install-strip
+
 # Build stage for GoTTY
 FROM golang:alpine AS gotty-builder
 
@@ -7,7 +19,7 @@ RUN apk add --no-cache git
 # Install GoTTY from source
 RUN go install github.com/sorenisanerd/gotty@v1.5.0
 
-# Final stage
+# Final image
 FROM alpine:3.18.6
 
 EXPOSE 22 80 443 1180 11443 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.18.6
 
-EXPOSE 22 80 443 1180 11443
+EXPOSE 22 80 443 1180 11443 8080
 
 # Install some tools in the container and generate self-signed SSL certificates.
 # Packages are listed in alphabetical order, for ease of readability and ease of maintenance.
@@ -47,22 +47,22 @@ COPY nginx.conf /etc/nginx/nginx.conf
 COPY .bashrc /root/.bashrc
 RUN echo 'if [ -f ~/.bashrc ]; then . ~/.bashrc; fi' > /root/.bash_profile
 
+# Install GoTTY binary only - NOT starting it automatically
+RUN wget -q -O /tmp/gotty.tar.gz https://github.com/sorenisanerd/gotty/releases/download/v1.5.0/gotty_v1.5.0_linux_amd64.tar.gz && \
+    tar -zxf /tmp/gotty.tar.gz -C /usr/local/bin && \
+    rm /tmp/gotty.tar.gz && \
+    chmod +x /usr/local/bin/gotty
+
+# Create directories for GoTTY service
+RUN mkdir -p /var/run/gotty /var/log/gotty
+
+COPY gotty-service /usr/local/bin/gotty-service
+RUN chmod +x /usr/local/bin/gotty-service
+
 COPY entrypoint.sh /docker/entrypoint.sh
 
 # Start nginx in foreground (pass CMD to docker entrypoint.sh):
 CMD ["/usr/sbin/nginx", "-g", "daemon off;"]
 
-# Note: If you have not included the "bash" package, then it is "mandatory" to add "/bin/sh"
-#         in the ENTNRYPOINT instruction.
-#       Otherwise you will get strange errors when you try to run the container.
-#       Such as:
-#       standard_init_linux.go:219: exec user process caused: no such file or directory
-
 # Run the startup script as ENTRYPOINT, which does few things and then starts nginx.
 ENTRYPOINT ["/bin/sh", "/docker/entrypoint.sh"]
-
-
-
-
-
-

--- a/gotty-service
+++ b/gotty-service
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# GoTTY service management script
+# Usage: gotty-service {start|stop|status|restart} [PORT] [USERNAME] [PASSWORD] [SHELL]
+
+# Default configuration
+PORT=${2:-8080}
+USERNAME=${3:-admin}
+PASSWORD=${4:-admin}
+SHELL=${5:-bash}
+TITLE="Network Multitool Terminal"
+
+# Paths
+PID_FILE="/var/run/gotty/gotty-${PORT}.pid"
+LOG_FILE="/var/log/gotty/gotty-${PORT}.log"
+
+# Ensure directories exist
+mkdir -p /var/run/gotty /var/log/gotty
+
+check_port() {
+    if netstat -tuln | grep -q ":$PORT "; then
+        if [ -f "$PID_FILE" ]; then
+            PID=$(cat "$PID_FILE")
+            if ps -p "$PID" > /dev/null; then
+                # Our GoTTY service is using this port
+                return 0
+            fi
+        fi
+        # Another service is using this port
+        echo "Error: Port $PORT is already in use by another service."
+        return 1
+    fi
+    return 0
+}
+
+start_gotty() {
+    if [ -f "$PID_FILE" ]; then
+        PID=$(cat "$PID_FILE")
+        if ps -p "$PID" > /dev/null; then
+            echo "GoTTY is already running on port $PORT (PID: $PID)"
+            return 0
+        else
+            # Stale PID file
+            rm "$PID_FILE"
+        fi
+    fi
+
+    check_port || return 1
+
+    echo "Starting GoTTY service on port $PORT..."
+    gotty -w -p "$PORT" -c "$USERNAME:$PASSWORD" --title-format "$TITLE" "$SHELL" > "$LOG_FILE" 2>&1 &
+
+    PID=$!
+    echo $PID > "$PID_FILE"
+
+    # Check if process is still running after a short delay
+    sleep 1
+    if ps -p "$PID" > /dev/null; then
+        echo "GoTTY service started successfully (PID: $PID)"
+        echo "Access web terminal at: http://<host-ip>:$PORT"
+        echo "Username: $USERNAME"
+        echo "Password: $PASSWORD"
+        return 0
+    else
+        echo "Failed to start GoTTY service. Check logs at $LOG_FILE"
+        rm -f "$PID_FILE"
+        return 1
+    fi
+}
+
+stop_gotty() {
+    if [ -f "$PID_FILE" ]; then
+        PID=$(cat "$PID_FILE")
+        if ps -p "$PID" > /dev/null; then
+            echo "Stopping GoTTY service on port $PORT (PID: $PID)..."
+            kill "$PID"
+
+            # Wait for process to terminate
+            for i in {1..5}; do
+                if ! ps -p "$PID" > /dev/null; then
+                    break
+                fi
+                sleep 1
+            done
+
+            # Check if process is still running
+            if ps -p "$PID" > /dev/null; then
+                echo "GoTTY service did not stop gracefully, forcing termination..."
+                kill -9 "$PID"
+            fi
+
+            rm -f "$PID_FILE"
+            echo "GoTTY service stopped"
+        else
+            echo "GoTTY service is not running on port $PORT (stale PID file)"
+            rm -f "$PID_FILE"
+        fi
+    else
+        echo "GoTTY service is not running on port $PORT"
+    fi
+}
+
+check_status() {
+    if [ -f "$PID_FILE" ]; then
+        PID=$(cat "$PID_FILE")
+        if ps -p "$PID" > /dev/null; then
+            echo "GoTTY service is running on port $PORT (PID: $PID)"
+            echo "Access web terminal at: http://<host-ip>:$PORT"
+            echo "Username: $USERNAME"
+            echo "Password: $PASSWORD"
+            return 0
+        else
+            echo "GoTTY service is not running on port $PORT (stale PID file)"
+            rm -f "$PID_FILE"
+            return 1
+        fi
+    else
+        echo "GoTTY service is not running on port $PORT"
+        return 1
+    fi
+}
+
+restart_gotty() {
+    stop_gotty
+    sleep 2
+    start_gotty
+}
+
+# Main logic
+case "$1" in
+    start)
+        start_gotty
+        ;;
+    stop)
+        stop_gotty
+        ;;
+    status)
+        check_status
+        ;;
+    restart)
+        restart_gotty
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|status|restart} [PORT] [USERNAME] [PASSWORD] [SHELL]"
+        echo "Default: PORT=8080, USERNAME=admin, PASSWORD=admin, SHELL=bash"
+        exit 1
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
This lets you adhoc create a gotty webterminal
https://github.com/sorenisanerd/gotty

```
docker run --network clab --rm -i -t \
  --name gotty-adhoc \
  -p 8080:8080 \
  -v /etc/hosts:/etc/hosts \
  --entrypoint '' -d \
  ghcr.io/srl-labs/network-multitool \
  sh -c "gotty-service start 8080 admin admin2 && tail -f /var/log/gotty/gotty-8080.log"
```

```
❯ docker exec gotty-adhoc gotty-service status
GoTTY service is running on port 8080 (PID: 11)
Access web terminal at: http://<host-ip>:8080
Username: admin
Password: admin
```

Not as fancy as sshx, but fully local and with credentials