### PR TITLE
update mcjoin to 2.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.18.6 AS builder
 
 RUN apk update && apk add --virtual .build-deps \
-    build-base gcc
+    build-base gcc wget
 
 RUN wget https://github.com/troglobit/mcjoin/releases/download/v2.12/mcjoin-2.12.tar.gz
 RUN tar -xzf mcjoin-2.12.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM alpine:3.18.6 AS builder
 RUN apk update && apk add --virtual .build-deps \
     build-base gcc
 
-RUN wget https://github.com/troglobit/mcjoin/releases/download/v2.11/mcjoin-2.11.tar.gz
-RUN tar -xzf mcjoin-2.11.tar.gz
-WORKDIR /mcjoin-2.11
+RUN wget https://github.com/troglobit/mcjoin/releases/download/v2.12/mcjoin-2.12.tar.gz
+RUN tar -xzf mcjoin-2.12.tar.gz
+WORKDIR /mcjoin-2.12
 RUN ./configure
 RUN make -j5
 RUN make install-strip


### PR DESCRIPTION
- updated mcjoin to 2.12 (has an important fix regarding memory RSS usage)
- added apk wget to builder (busybox wget version has trouble when https_proxy is used)